### PR TITLE
added node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#node_modules
+node_modules


### PR DESCRIPTION
Add node_modules to .gitignore file to avoid large untracked files when "npm install" is run