### PR TITLE
Update .gitignore. Add "node_modules/" folder to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Node modules
+node_modules/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Files contained in /node_modules folders are no longer committed with this .gitignore configuration.

The old configuration added installed node modules, which bloats the remote repository after a local build.